### PR TITLE
moving vows to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "type" : "git",
     "url"  : "https://github.com/benadida/node-hkdf"
   },
-  "dependencies" : {
+  "devDependencies" : {
     "vows": "0.5.13"
   },
   "author" : {


### PR DESCRIPTION
Seems like `vows` is only needed for running tests, so we don't need it when we `npm install` the module?
